### PR TITLE
feat: Implement AuthController with endpoints and unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,31 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
+		<!-- Add JAXB dependencies -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/sinolanka/assessment/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sinolanka/assessment/config/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.sinolanka.assessment.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        String token = null;
+        String username = null;
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            token = authHeader.substring(7); // Remove "Bearer " prefix
+            username = jwtUtil.extractUsername(token);
+        }
+
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            if (jwtUtil.validateToken(token)) {
+                UsernamePasswordAuthenticationToken authToken =
+                        new UsernamePasswordAuthenticationToken(
+                                username,
+                                null,
+                                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+                        );
+
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+
+            }
+
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sinolanka/assessment/config/JwtUtil.java
+++ b/src/main/java/com/sinolanka/assessment/config/JwtUtil.java
@@ -1,0 +1,37 @@
+package com.sinolanka.assessment.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    public String extractUsername(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .setSigningKey(jwtSecret.getBytes()) // Ensure consistent encoding
+                    .parseClaimsJws(token) // Use parseClaimsJws for signed JWTs
+                    .getBody();
+            return claims.getSubject();
+        } catch (Exception e) {
+            System.out.println("Error extracting username: " + e.getMessage());
+            return null;
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(jwtSecret.getBytes())
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            System.out.println("Error validating token: " + e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/sinolanka/assessment/config/SecurityConfig.java
+++ b/src/main/java/com/sinolanka/assessment/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.sinolanka.assessment.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    // Constructor injection for the JWT filter
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable() // Disable CSRF for stateless API
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // No sessions
+                .and()
+                .authorizeHttpRequests(auth -> auth
+                        // Public endpoints
+                        .requestMatchers("/api/auth/register", "/api/auth/login").permitAll()
+                        // History endpoint: authenticated users only
+                        .requestMatchers("/api/auth/history/{username}").authenticated()
+                        // Any other request requires authentication
+                        .anyRequest().authenticated()
+                )
+                // Add JWT filter before UsernamePasswordAuthenticationFilter
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/sinolanka/assessment/controller/AuthController.java
+++ b/src/main/java/com/sinolanka/assessment/controller/AuthController.java
@@ -1,0 +1,59 @@
+package com.sinolanka.assessment.controller;
+
+import com.sinolanka.assessment.dto.LoginHistoryResponse;
+import com.sinolanka.assessment.dto.LoginRequest;
+import com.sinolanka.assessment.dto.UserRegisterRequest;
+import com.sinolanka.assessment.entity.User;
+import com.sinolanka.assessment.service.LoginAttemptService;
+import com.sinolanka.assessment.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final UserService userService;
+    private final LoginAttemptService loginAttemptService;
+
+    public AuthController(UserService userService, LoginAttemptService loginAttemptService) {
+        this.userService = userService;
+        this.loginAttemptService = loginAttemptService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<User> register(@Valid @RequestBody UserRegisterRequest request) {
+        User user = userService.registerUser(request);
+        if (user == null) {
+            // Log or handle the case when user is null
+            return ResponseEntity.badRequest().body(null);
+        }
+        return ResponseEntity.ok(user);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody LoginRequest request) {
+        try {
+            String token = userService.loginUser(request.getUsername(), request.getPassword());
+            loginAttemptService.recordAttempt(request.getUsername(), true);
+            return ResponseEntity.ok(token);
+        } catch (Exception e) {
+            loginAttemptService.recordAttempt(request.getUsername(), false);
+            return ResponseEntity.status(401).body("Login failed");
+        }
+    }
+
+    @GetMapping("/history/{username}")
+    public ResponseEntity<List<LoginHistoryResponse>> getLoginHistory(@PathVariable String username, Authentication authentication) {
+        if (!authentication.getName().equals(username)) {
+            System.out.println("Authenticated user = " + authentication.getName());
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        return ResponseEntity.ok(loginAttemptService.getLoginHistory(username));
+    }
+
+}

--- a/src/main/java/com/sinolanka/assessment/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/sinolanka/assessment/controller/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.sinolanka.assessment.controller;
+
+import com.sinolanka.assessment.exception.DuplicateUserException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(DuplicateUserException.class)
+    public ResponseEntity<String> handleDuplicateUserException(DuplicateUserException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/sinolanka/assessment/dto/LoginHistoryResponse.java
+++ b/src/main/java/com/sinolanka/assessment/dto/LoginHistoryResponse.java
@@ -1,0 +1,11 @@
+package com.sinolanka.assessment.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class LoginHistoryResponse {
+    private LocalDateTime timestamp;
+    private boolean success;
+}

--- a/src/main/java/com/sinolanka/assessment/dto/LoginRequest.java
+++ b/src/main/java/com/sinolanka/assessment/dto/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.sinolanka.assessment.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String username;
+    private String password;
+
+    // Constructor to initialize fields
+    public LoginRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/sinolanka/assessment/dto/UserRegisterRequest.java
+++ b/src/main/java/com/sinolanka/assessment/dto/UserRegisterRequest.java
@@ -1,0 +1,25 @@
+package com.sinolanka.assessment.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UserRegisterRequest {
+    @NotBlank(message = "Username is required")
+    private String username;
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    private String password;
+
+    // Constructor to initialize fields
+    public UserRegisterRequest(String username, String email, String password) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/sinolanka/assessment/entity/LoginAttempt.java
+++ b/src/main/java/com/sinolanka/assessment/entity/LoginAttempt.java
@@ -1,0 +1,18 @@
+package com.sinolanka.assessment.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+public class LoginAttempt {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private User user;
+    private LocalDateTime timestamp;
+    private boolean success;
+}

--- a/src/main/java/com/sinolanka/assessment/entity/User.java
+++ b/src/main/java/com/sinolanka/assessment/entity/User.java
@@ -1,0 +1,30 @@
+package com.sinolanka.assessment.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+@Entity
+@Data
+@Table(name = "app_user")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password; // Hashed in production
+
+    public User(String username, String email, String password) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+    }
+
+
+    public User() {}
+}

--- a/src/main/java/com/sinolanka/assessment/exception/DuplicateUserException.java
+++ b/src/main/java/com/sinolanka/assessment/exception/DuplicateUserException.java
@@ -1,0 +1,7 @@
+package com.sinolanka.assessment.exception;
+
+public class DuplicateUserException extends RuntimeException {
+    public DuplicateUserException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sinolanka/assessment/repository/LoginAttemptRepository.java
+++ b/src/main/java/com/sinolanka/assessment/repository/LoginAttemptRepository.java
@@ -1,0 +1,10 @@
+package com.sinolanka.assessment.repository;
+import com.sinolanka.assessment.entity.LoginAttempt;
+import com.sinolanka.assessment.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LoginAttemptRepository extends JpaRepository<LoginAttempt, Long> {
+    List<LoginAttempt> findTop5ByUserOrderByTimestampDesc(User user);
+}

--- a/src/main/java/com/sinolanka/assessment/repository/UserRepository.java
+++ b/src/main/java/com/sinolanka/assessment/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.sinolanka.assessment.repository;
+
+import com.sinolanka.assessment.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/sinolanka/assessment/service/LoginAttemptService.java
+++ b/src/main/java/com/sinolanka/assessment/service/LoginAttemptService.java
@@ -1,0 +1,47 @@
+package com.sinolanka.assessment.service;
+
+import com.sinolanka.assessment.dto.LoginHistoryResponse;
+import com.sinolanka.assessment.entity.LoginAttempt;
+import com.sinolanka.assessment.entity.User;
+import com.sinolanka.assessment.repository.LoginAttemptRepository;
+import com.sinolanka.assessment.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LoginAttemptService {
+    private final LoginAttemptRepository loginAttemptRepository;
+    private final UserRepository userRepository;
+
+    public LoginAttemptService(LoginAttemptRepository loginAttemptRepository, UserRepository userRepository) {
+        this.loginAttemptRepository = loginAttemptRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void recordAttempt(String username, boolean success) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        LoginAttempt attempt = new LoginAttempt();
+        attempt.setUser(user);
+        attempt.setTimestamp(LocalDateTime.now());
+        attempt.setSuccess(success);
+        loginAttemptRepository.save(attempt);
+    }
+
+    public List<LoginHistoryResponse> getLoginHistory(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return loginAttemptRepository.findTop5ByUserOrderByTimestampDesc(user)
+                .stream()
+                .map(attempt -> {
+                    LoginHistoryResponse response = new LoginHistoryResponse();
+                    response.setTimestamp(attempt.getTimestamp());
+                    response.setSuccess(attempt.isSuccess());
+                    return response;
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/sinolanka/assessment/service/UserService.java
+++ b/src/main/java/com/sinolanka/assessment/service/UserService.java
@@ -1,0 +1,55 @@
+package com.sinolanka.assessment.service;
+
+import com.sinolanka.assessment.dto.UserRegisterRequest;
+import com.sinolanka.assessment.entity.User;
+import com.sinolanka.assessment.exception.DuplicateUserException;
+import com.sinolanka.assessment.repository.UserRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    // Expose the jwtSecret for mocking in tests
+    @Getter
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User registerUser(UserRegisterRequest request) {
+        if (userRepository.findByUsername(request.getUsername()).isPresent()) {
+            throw new DuplicateUserException("Username already exists");
+        }
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new DuplicateUserException("Email already exists");
+        }
+
+        User user = new User();
+        user.setUsername(request.getUsername());
+        user.setEmail(request.getEmail());
+        user.setPassword(request.getPassword());
+        return userRepository.save(user);
+    }
+
+    public String loginUser(String username, String password) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        if (!user.getPassword().equals(password)) {
+            throw new RuntimeException("Invalid credentials");
+        }
+        return Jwts.builder()
+                .setSubject(user.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 86400000))
+                .signWith(SignatureAlgorithm.HS512, jwtSecret.getBytes()) // Use byte[] explicitly
+                .compact();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,10 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/social_scheduler
+# PostgreSQL Database Configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/user_management
 spring.datasource.username=postgres
-spring.datasource.password=yourpassword
-spring.jpa.hibernate.ddl-auto=update
+spring.datasource.password=admin
+
+# JPA/Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
-jwt.secret=your-secret-key-here
+
+jwt.secret=

--- a/src/test/java/com/sinolanka/assessment/controller/AuthControllerTest.java
+++ b/src/test/java/com/sinolanka/assessment/controller/AuthControllerTest.java
@@ -1,0 +1,130 @@
+package com.sinolanka.assessment.controller;
+
+import com.sinolanka.assessment.dto.LoginHistoryResponse;
+import com.sinolanka.assessment.dto.LoginRequest;
+import com.sinolanka.assessment.dto.UserRegisterRequest;
+import com.sinolanka.assessment.entity.User;
+import com.sinolanka.assessment.repository.UserRepository;
+import com.sinolanka.assessment.service.LoginAttemptService;
+import com.sinolanka.assessment.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthControllerTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private LoginAttemptService loginAttemptService;
+
+    @InjectMocks
+    private AuthController authController;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Mock
+    private UserRepository userRepository;
+
+
+    @Test
+    public void testRegisterUser() {
+        // Arrange
+        UserRegisterRequest request = new UserRegisterRequest("testuser", "test@example.com", "password");
+        User expectedUser = new User("testuser", "test@example.com", "password");
+
+        // Ensure the mock returns the expected User object
+        Mockito.when(userService.registerUser(Mockito.any(UserRegisterRequest.class))).thenReturn(expectedUser);
+
+        // Act
+        ResponseEntity<User> response = authController.register(request);
+
+        // Assert
+        assertNotNull(response.getBody());  // This will now pass if the response body is not null
+        assertEquals("testuser", response.getBody().getUsername());
+    }
+
+    @Test
+    void testLoginSuccess() {
+        // Arrange
+        LoginRequest loginRequest = new LoginRequest("testuser", "password123");
+        String token = "jwt_token";
+        when(userService.loginUser(loginRequest.getUsername(), loginRequest.getPassword())).thenReturn(token);
+
+        // Act
+        ResponseEntity<String> response = authController.login(loginRequest);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(token, response.getBody());
+        verify(loginAttemptService).recordAttempt(loginRequest.getUsername(), true);
+    }
+
+    @Test
+    void testLoginFailed() {
+        // Arrange
+        LoginRequest loginRequest = new LoginRequest("testuser", "wrongpassword");
+        when(userService.loginUser(loginRequest.getUsername(), loginRequest.getPassword())).thenThrow(new RuntimeException("Invalid credentials"));
+
+        // Act
+        ResponseEntity<String> response = authController.login(loginRequest);
+
+        // Assert
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertEquals("Login failed", response.getBody());
+        verify(loginAttemptService).recordAttempt(loginRequest.getUsername(), false);
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    void testGetLoginHistorySuccess() {
+        // Arrange
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn("testuser");
+
+        LoginHistoryResponse historyResponse = new LoginHistoryResponse();
+        historyResponse.setTimestamp(LocalDateTime.parse("2023-04-08T10:00:00"));
+        historyResponse.setSuccess(true);
+        List<LoginHistoryResponse> history = List.of(historyResponse);
+
+        when(loginAttemptService.getLoginHistory("testuser")).thenReturn(history);
+
+        // Act
+        ResponseEntity<List<LoginHistoryResponse>> response = authController.getLoginHistory("testuser", authentication);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertFalse(response.getBody().isEmpty());
+
+        // Adjusted comparison to ignore seconds
+        assertEquals("2023-04-08T10:00", response.getBody().get(0).getTimestamp().toString().substring(0, 16));
+    }
+
+
+    @Test
+    void testGetLoginHistoryForbidden() {
+        // Arrange
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn("anotheruser");
+
+        // Act
+        ResponseEntity<List<LoginHistoryResponse>> response = authController.getLoginHistory("testuser", authentication);
+
+        // Assert
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+}

--- a/src/test/java/com/sinolanka/assessment/service/LoginAttemptServiceTest.java
+++ b/src/test/java/com/sinolanka/assessment/service/LoginAttemptServiceTest.java
@@ -1,0 +1,72 @@
+package com.sinolanka.assessment.service;
+import com.sinolanka.assessment.dto.LoginHistoryResponse;
+import com.sinolanka.assessment.entity.LoginAttempt;
+import com.sinolanka.assessment.entity.User;
+import com.sinolanka.assessment.repository.LoginAttemptRepository;
+import com.sinolanka.assessment.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoginAttemptServiceTest {
+
+    @Mock
+    private LoginAttemptRepository loginAttemptRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private LoginAttemptService loginAttemptService;
+
+    private User user;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        user = new User();
+        user.setUsername("testuser");
+    }
+
+    @Test
+    void testRecordAttempt() {
+        // Arrange
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+        LoginAttempt attempt = new LoginAttempt();
+        attempt.setUser(user);
+        attempt.setTimestamp(LocalDateTime.now());
+        attempt.setSuccess(true);
+
+        // Act
+        loginAttemptService.recordAttempt("testuser", true);
+
+        // Assert
+        verify(loginAttemptRepository).save(any(LoginAttempt.class));
+    }
+
+    @Test
+    void testGetLoginHistory() {
+        // Arrange
+        LoginAttempt attempt = new LoginAttempt();
+        attempt.setUser(user);
+        attempt.setTimestamp(LocalDateTime.now());
+        attempt.setSuccess(true);
+
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(loginAttemptRepository.findTop5ByUserOrderByTimestampDesc(user)).thenReturn(List.of(attempt));
+
+        // Act
+        List<LoginHistoryResponse> response = loginAttemptService.getLoginHistory("testuser");
+
+        // Assert
+        assertFalse(response.isEmpty());
+        assertEquals(1, response.size());
+    }
+}

--- a/src/test/java/com/sinolanka/assessment/service/UserServiceTest.java
+++ b/src/test/java/com/sinolanka/assessment/service/UserServiceTest.java
@@ -1,0 +1,135 @@
+package com.sinolanka.assessment.service;
+
+import com.sinolanka.assessment.dto.UserRegisterRequest;
+import com.sinolanka.assessment.entity.User;
+import com.sinolanka.assessment.exception.DuplicateUserException;
+import com.sinolanka.assessment.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Date;
+import java.util.Optional;
+
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+    @Test
+    void testRegisterUserSuccess() {
+        // Arrange
+        UserRegisterRequest request = new UserRegisterRequest("testuser", "testemail@test.com", "password123");
+        User user = new User();
+        user.setUsername(request.getUsername());
+        user.setEmail(request.getEmail());
+        user.setPassword(request.getPassword());
+
+        // Mock repository behavior
+        when(userRepository.findByUsername(request.getUsername())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User savedUser = invocation.getArgument(0);
+            savedUser.setUsername("testuser"); // Ensure the username is set on save
+            return savedUser; // Simulate the saved user
+        });
+
+        // Act
+        User registeredUser = userService.registerUser(request);
+
+        // Assert
+        assertNotNull(registeredUser);
+        assertEquals("testuser", registeredUser.getUsername()); // Ensure the username is correctly set
+    }
+
+
+
+    @Test
+    void testRegisterUserDuplicateUsername() {
+        // Arrange
+        UserRegisterRequest request = new UserRegisterRequest("testuser", "testemail@test.com", "password123");
+        when(userRepository.findByUsername(request.getUsername())).thenReturn(Optional.of(new User()));
+
+        // Act & Assert
+        assertThrows(DuplicateUserException.class, () -> userService.registerUser(request));
+    }
+
+    @Test
+    void testLoginUserSuccess() {
+        // Arrange
+        String username = "testuser";
+        String password = "password123";
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(password);
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+
+        // Manually set the value of jwtSecret using ReflectionTestUtils
+        String jwtSecret = "jwtsecretkey";
+        ReflectionTestUtils.setField(userService, "jwtSecret", jwtSecret);
+
+        // Define the expected token structure (without the exact signature)
+        String expectedSubject = username;
+        long currentTimeMillis = System.currentTimeMillis();
+        long expirationTimeMillis = currentTimeMillis + 86400000;
+
+        String token = Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date(currentTimeMillis))
+                .setExpiration(new Date(expirationTimeMillis))
+                .signWith(SignatureAlgorithm.HS512, jwtSecret.getBytes())
+                .compact();
+
+        // Act
+        String tokenResponse = userService.loginUser(username, password);
+
+        // Assert: Decode the JWT token and check its claims
+        Claims claims = Jwts.parser()
+                .setSigningKey(jwtSecret.getBytes())
+                .parseClaimsJws(tokenResponse)
+                .getBody();
+
+        assertEquals(expectedSubject, claims.getSubject());
+
+        // Log the times for debugging
+        long issuedAtTime = claims.getIssuedAt().getTime();
+        System.out.println("currentTimeMillis: " + currentTimeMillis);
+        System.out.println("issuedAtTime: " + issuedAtTime);
+
+        // Allow for a larger time window, e.g., 2 seconds
+        assertTrue(issuedAtTime >= currentTimeMillis - 2000);  // Allow for 2 seconds tolerance
+        assertTrue(issuedAtTime <= currentTimeMillis + 2000);  // Allow for 2 seconds tolerance
+
+        assertTrue(claims.getExpiration().getTime() <= expirationTimeMillis);  // Check if expiration time is less than or equal to the expected expiration time
+    }
+
+
+
+    @Test
+    void testLoginUserFailure() {
+        // Arrange
+        String username = "testuser";
+        String password = "wrongpassword";
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword("password123");
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+
+        // Act & Assert
+        assertThrows(RuntimeException.class, () -> userService.loginUser(username, password));
+    }
+}


### PR DESCRIPTION
- Add AuthController with /api/auth/register, /api/auth/login, and /api/auth/history/{username} endpoints
- Implement register to create a new user via UserService
- Implement login to authenticate and return JWT token with LoginAttemptService logging
- Implement getLoginHistory to fetch login history with authentication check
- Create AuthControllerTest with unit tests for all endpoints
- Test registerUser for successful user registration
- Test loginSuccess and loginFailed for authentication scenarios